### PR TITLE
feature: Build APK repo

### DIFF
--- a/.github/actions/make-apkindex/Dockerfile
+++ b/.github/actions/make-apkindex/Dockerfile
@@ -1,0 +1,6 @@
+
+FROM alpine:edge
+RUN apk --update add alpine-sdk
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+ENTRYPOINT /entrypoint.sh

--- a/.github/actions/make-apkindex/README.md
+++ b/.github/actions/make-apkindex/README.md
@@ -1,0 +1,54 @@
+# Make Alpine Linux APK Package Index
+
+This action builds an Alpine Linux package repository from a set of APK files.
+
+## Inputs
+
+## `apk_files`
+
+**Required** The files to include in the repo. Default `"dist/*.apk"`.
+
+## `signature_key`
+
+**Required** The RSA private key to sign the repository.
+
+## `signature_key_name`
+
+**Required** The signature key name. It needs to match the name of the public
+key that is installed in `/etc/apk/keys`. For instance, if the public key
+filename is `kaweezle-devel@kaweezle.com-c9d89864.rsa.pub`, the name of the key
+should be `kaweezle-devel@kaweezle.com-c9d89864.rsa`.
+
+## `destination`
+
+**Required** The directory where to create the repo. Default `"dist/repo"`.
+
+## Outputs
+
+None.
+
+## APK file names
+
+The action expects the APK file name to have the following syntax:
+
+```
+<package_name>-<version>.<arch>.apk
+```
+
+For instance:
+
+```
+iknite-0.1.8.x86_64.apk
+```
+
+## Example usage
+
+```yaml
+- name: Build APK repo
+  uses: ./.github/actions/make-apkindex
+  with:
+      apk_files: dist/*.apk
+      signature_key: "${{ secrets.GPG_PRIVATE_KEY }}"
+      signature_key_name: kaweezle-devel@kaweezle.com-c9d89864.rsa
+      destination: dist/repo
+```

--- a/.github/actions/make-apkindex/action.yml
+++ b/.github/actions/make-apkindex/action.yml
@@ -1,0 +1,26 @@
+name: "Alpine Build APK Index"
+description: "Build Alpine Linux repository from a set of APK files"
+author: Antoine Martin <antoine@openance.com>
+inputs:
+  apk_files:
+    description: "Set of APK files"
+    required: true
+    default: "dist/*.apk"
+  signature_key:
+    description: "APK index signature key"
+    required: true
+  signature_key_name:
+    description: "APK index signature key name"
+    required: true
+  destination:
+    description: "Destination directory (from the workspace)"
+    required: true
+    default: "dist/repo"
+
+runs:
+  using: "docker"
+  image: "Dockerfile"
+
+branding:
+  icon: "package"
+  color: "blue"

--- a/.github/actions/make-apkindex/entrypoint.sh
+++ b/.github/actions/make-apkindex/entrypoint.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env sh
+
+set -e
+
+echo "::group::Setup"
+
+cd $GITHUB_WORKSPACE
+
+if [[ -z "$INPUT_APK_FILES" ]]; then
+    echo "No APK files given!"
+    exit 1
+fi
+
+if  [[ -z "$INPUT_SIGNATURE_KEY_NAME" ]]; then
+    echo "No signature key name given!"
+    exit 1
+fi
+
+if  [[ -z "$INPUT_SIGNATURE_KEY" ]]; then
+    echo "No signature key given!"
+    exit 1
+else
+    signature_file="/root/$INPUT_SIGNATURE_KEY_NAME"
+    printf "$INPUT_SIGNATURE_KEY" > "$signature_file"
+fi
+
+if [[ -z "$INPUT_DESTINATION" ]]; then
+    echo "No destination given!"
+    exit 1
+fi
+
+files=$(ls -1 $INPUT_APK_FILES 2>/dev/null)
+files_count=$(echo "$files" | wc -l)
+if [[ "$files_count" -eq 0 ]]; then
+    echo "There are no apk files matching $INPUT_APK_FILES"
+    exit 1
+fi
+
+archs=$(ls -1 $INPUT_APK_FILES 2>/dev/null | sed -E 's/^.*\.(.*)\.apk$/\1/g')
+archs_count=$(echo "$archs" | wc -l)
+if [[ "$archs_count" -eq 0 ]]; then
+    echo "No architectures found in APK files: $files"
+    exit 1
+fi
+
+echo "Creating repo in $INPUT_DESTINATION from $files_count APK files with $archs_count architectures..."
+
+echo "::endgroup::"
+
+
+echo "::group::Creating repo in $INPUT_DESTINATION"
+
+
+rm -rf $INPUT_DESTINATION
+mkdir -p $INPUT_DESTINATION
+
+for arch in $archs; do
+    arch_directory="${INPUT_DESTINATION}/$arch"
+    echo "Creating directory $arch_directory"
+    mkdir -p "$arch_directory"
+done
+
+for file in $(echo "$files"); do
+    file_basename=$(basename "$file")
+    file_arch=$(echo "$file_basename" | sed -E 's/^.*\.(.*)\.apk$/\1/g')
+    destination_filename=$(echo "$file_basename" | sed -E 's/^(.*)\.[^.]*\.apk$/\1.apk/g')
+    echo "Copying ${file} to ${INPUT_DESTINATION}/${file_arch}/${destination_filename}..."
+    cp -f "${file}" "${INPUT_DESTINATION}/${file_arch}/${destination_filename}"
+done
+
+echo "::endgroup::"
+
+
+echo "::group::Creating indexes"
+
+for arch in $archs; do
+    arch_directory="${INPUT_DESTINATION}/$arch"
+    index_file="${arch_directory}/APKINDEX.tar.gz"
+    apk index -o "${index_file}" "${arch_directory}"/*.apk 2>/dev/null
+    abuild-sign -k "${signature_file}" "${index_file}"
+done
+
+echo "::endgroup::"
+
+

--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -19,8 +19,10 @@ jobs:
       - name: Import Signature key
         shell: bash
         run: |
-          echo -e "${{ secrets.GPG_PRIVATE_KEY }}" | openssl base64 -d -A > gpg_key.asc
+          echo -e "$GPG_PRIVATE_KEY" > gpg_key.asc
           openssl rsa -in gpg_key.asc -pubout -out kaweezle-devel@kaweezle.com-c9d89864.rsa.pub
+        env:
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
       - name: Run GoReleaser Tests
         uses: goreleaser/goreleaser-action@v2
         with:
@@ -28,3 +30,10 @@ jobs:
           args: --snapshot --skip-publish --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build APK repo
+        uses: ./.github/actions/make-apkindex
+        with:
+          apk_files: dist/*.apk
+          signature_key: "${{ secrets.GPG_PRIVATE_KEY }}"
+          signature_key_name: kaweezle-devel@kaweezle.com-c9d89864.rsa
+          destination: dist/repo

--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -37,3 +37,17 @@ jobs:
           signature_key: "${{ secrets.GPG_PRIVATE_KEY }}"
           signature_key_name: kaweezle-devel@kaweezle.com-c9d89864.rsa
           destination: dist/repo
+      - name: Commit repo to kaweezle.com
+        uses: cpina/github-action-push-to-another-repository@main
+        env:
+          API_TOKEN_GITHUB: ${{ secrets.REPO_ACCESS_TOKEN }}
+        with:
+          source-directory: dist/repo
+          destination-github-username: kaweezle
+          destination-repository-name: kaweezle.github.io
+          # TODO: replace with kaweezle-devel
+          user-name: antoinemartin
+          user-email: antoine@openance.com
+          target-branch: release-test
+          target-directory: docs/repo
+          commit-message: iknite APK repo ${{ github.ref_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,27 @@ jobs:
           args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build APK repo
+        uses: ./.github/actions/make-apkindex
+        with:
+          apk_files: dist/*.apk
+          signature_key: "${{ secrets.GPG_PRIVATE_KEY }}"
+          signature_key_name: kaweezle-devel@kaweezle.com-c9d89864.rsa
+          destination: dist/repo
+      - name: Commit repo to kaweezle.com
+        uses: cpina/github-action-push-to-another-repository@main
+        env:
+          API_TOKEN_GITHUB: ${{ secrets.REPO_ACCESS_TOKEN }}
+        with:
+          source-directory: dist/repo
+          destination-github-username: kaweezle
+          destination-repository-name: kaweezle.github.io
+          # TODO: replace with kaweezle-devel
+          user-name: antoinemartin
+          user-email: antoine@openance.com
+          target-branch: main
+          target-directory: docs/repo
+          commit-message: iknite APK repo ${{ github.ref_name }}
       - name: Trigger root fs build
         uses: peter-evans/repository-dispatch@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,8 +19,10 @@ jobs:
       - name: Import Signature key
         shell: bash
         run: |
-          echo -e "${{ secrets.GPG_PRIVATE_KEY }}" | openssl base64 -d -A > gpg_key.asc
+          echo -e "$GPG_PRIVATE_KEY" > gpg_key.asc
           openssl rsa -in gpg_key.asc -pubout -out kaweezle-devel@kaweezle.com-c9d89864.rsa.pub
+        env:
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -47,6 +47,12 @@ nfpms:
   - formats: [apk]
     license: Apache 2.0
     package_name: iknite
+    file_name_template:
+      "{{ .PackageName }}-{{ .Version }}.{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{
+      end }}{{ if .Mips }}_{{ .Mips }}{{ end }}"
+    replacements:
+      amd64: x86_64
+      "386": x86
     maintainer: Kaweezle <kaweezle-devel@kaweezle.com>
     description: Start Kubernetes in Alpine Linux
     homepage: https://github.com/kaweezle/iknite

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -43,7 +43,7 @@ var rootCmd = &cobra.Command{
 Makes the appropriate initialization of a WSL 2 Alpine distribution for running
 kubernetes.`,
 	Example: `> iknite start`,
-	Version: "v0.1.8", // <---VERSION--->
+	Version: "v0.1.9", // <---VERSION--->
 	// Uncomment the following line if your bare application
 	// has an action associated with it:
 	// Run: func(cmd *cobra.Command, args []string) { },


### PR DESCRIPTION
Build the APK packages repository containing the APK just released. It will then be easier for https://github.com/kaweezle/kaweezle-rootfs to install and/or update iknite.

Having a public APK repo available also makes possible installing iknite through [cloud-init](https://cloudinit.readthedocs.io/en/latest/) on cloud based VMs.

