### PR TITLE
⚡️ Do not reapply configuration if already done

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -43,7 +43,7 @@ var rootCmd = &cobra.Command{
 Makes the appropriate initialization of a WSL 2 Alpine distribution for running
 kubernetes.`,
 	Example: `> iknite start`,
-	Version: "v0.1.19", // <---VERSION--->
+	Version: "v0.1.20", // <---VERSION--->
 	// Uncomment the following line if your bare application
 	// has an action associated with it:
 	// Run: func(cmd *cobra.Command, args []string) { },

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -118,13 +118,9 @@ func perform(cmd *cobra.Command, args []string) {
 
 	cobra.CheckErr(config.RenameConfig(ClusterName).WriteToFile(constants.KubernetesRootConfig))
 
-	// Apply base customization. This adds the following to the cluster
-	// - MetalLB
-	// - Flannel
-	// - Local path provisioner
-	// - Metrics server
-	// The outbound ip address is needed for MetalLB.
-	cobra.CheckErr(doConfiguration(ip, config))
+	force, err := cmd.Flags().GetBool("force-config")
+	cobra.CheckErr(err)
+	cobra.CheckErr(doConfiguration(ip, config, force))
 
 	log.Info("executed")
 }


### PR DESCRIPTION
We write a configmap named `iknite-config` in the `kube-system` namespace. Configuration can be forced with the `--force-config` (or `-C`) flag.